### PR TITLE
fix: make the timer label to show on TimerWindow only when the timer was started

### DIFF
--- a/src/SpeechTime/Windows/ControlWindow.xaml.cs
+++ b/src/SpeechTime/Windows/ControlWindow.xaml.cs
@@ -61,7 +61,10 @@ namespace SpeechTime.Windows
             bleeper.Play(timerValue, new TimeSpan(0, 0, 10));
 
             if (timerValue.Equals(TimeSpan.Zero))
+            {
                 timer.Reset();
+                timerWindow.TimerValueLabel.Visibility = Visibility.Hidden;
+            }
         }
 
         private void TimerStartStopButton_Click(object sender, RoutedEventArgs e)
@@ -75,6 +78,7 @@ namespace SpeechTime.Windows
             {
                 timer.Start();
                 TimerControlPanel.Background = new SolidColorBrush(Colors.Honeydew);
+                timerWindow.TimerValueLabel.Visibility = Visibility.Visible;
             }
         }
 
@@ -82,6 +86,7 @@ namespace SpeechTime.Windows
         {
             timer.Reset();
             TimerControlPanel.Background = new SolidColorBrush(Colors.MistyRose);
+            timerWindow.TimerValueLabel.Visibility = Visibility.Hidden;
         }
 
         private void StopwatchStartStopButton_Click(object sender, RoutedEventArgs e)
@@ -122,6 +127,7 @@ namespace SpeechTime.Windows
 
             timer.InitialValue = AppSettings.TimerLimit;
             timer.Reset();
+            timerWindow.TimerValueLabel.Visibility = Visibility.Hidden;
 
             panelWindow.Panel.Background = new SolidColorBrush(AppSettings.PanelWindowBackground);
             panelWindow.CurrentDateTimeLabel.Foreground = new SolidColorBrush(AppSettings.PanelWindowForeground);

--- a/src/SpeechTime/Windows/TimerWindow.xaml
+++ b/src/SpeechTime/Windows/TimerWindow.xaml
@@ -10,7 +10,7 @@
     
     <Grid>
         <Viewbox>
-            <Label x:Name="TimerValueLabel" Content="00:10:00" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" FontSize="480" Foreground="#ffffff" Padding="100 0 100 0"/>
+            <Label x:Name="TimerValueLabel" Content="00:10:00" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" FontSize="480" Foreground="#ffffff" Padding="100 0 100 0" Visibility="Hidden"/>
         </Viewbox>
     </Grid>
 </Window>


### PR DESCRIPTION
Done by editing Visibility property of the WPF control and adding code that switch the property on Start/Reset timer in ControlWindow.